### PR TITLE
Implemented additional functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## [Made by following this official React tutorial](https://react.dev/learn/tutorial-tic-tac-toe)
+
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/src/App.css
+++ b/src/App.css
@@ -51,6 +51,9 @@ body {
   font-family: sans-serif;
   margin: 20px;
   padding: 0;
+
+  display: flex;
+  justify-content: center;
 }
 
 h1 {
@@ -133,4 +136,8 @@ body {
 
 .game-info {
   margin-left: 20px;
+}
+
+.square.highlight {
+  background-color: green;
 }


### PR DESCRIPTION
1. For the current move only, show “You are at move #…” instead of a button.
2. Rewrite Board to use two loops to make the squares instead of hardcoding them.
3. Add a toggle button that lets you sort the moves in either ascending or descending order.
4. When someone wins, highlight the three squares that caused the win (and when no one wins, display a message about the result being a draw).
5. Display the location for each move in the format (_player_ at _row_, _col_) in the move history list.